### PR TITLE
feat(http-instrumentation) enable custom metrics attributes

### DIFF
--- a/experimental/packages/opentelemetry-instrumentation-http/src/http.ts
+++ b/experimental/packages/opentelemetry-instrumentation-http/src/http.ts
@@ -379,7 +379,8 @@ export class HttpInstrumentation extends InstrumentationBase<Http> {
                 this._getConfig().applyCustomAttributesOnSpan!(
                   span,
                   request,
-                  response
+                  response,
+                  metricAttributes
                 ),
               () => {},
               true
@@ -750,7 +751,8 @@ export class HttpInstrumentation extends InstrumentationBase<Http> {
           this._getConfig().applyCustomAttributesOnSpan!(
             span,
             request,
-            response
+            response,
+            metricAttributes
           ),
         () => {},
         true

--- a/experimental/packages/opentelemetry-instrumentation-http/src/types.ts
+++ b/experimental/packages/opentelemetry-instrumentation-http/src/types.ts
@@ -26,6 +26,7 @@ import {
 } from 'http';
 import * as url from 'url';
 import { InstrumentationConfig } from '@opentelemetry/instrumentation';
+import {MetricAttributes} from "@opentelemetry/api/build/esnext";
 
 export type IgnoreMatcher = string | RegExp | ((url: string) => boolean);
 export type HttpCallback = (res: IncomingMessage) => void;
@@ -52,7 +53,8 @@ export interface HttpCustomAttributeFunction {
   (
     span: Span,
     request: ClientRequest | IncomingMessage,
-    response: IncomingMessage | ServerResponse
+    response: IncomingMessage | ServerResponse,
+    metricsAttributes: MetricAttributes
   ): void;
 }
 


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋:tada:

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

Add metricsAttributes to `applyCustomAttributesOnSpan()`, so it is possible to to apply custom attributes to metrics attributes

Fixes #3694

## Short description of the changes

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Manual test

## Checklist:

- [x] Followed the style guidelines of this project